### PR TITLE
FIX delete deprecated file Object.php

### DIFF
--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -4137,7 +4137,8 @@ function migrate_delete_old_files($db, $langs, $conf)
 		'/core/modules/mailings/poire.modules.php',
 		'/core/modules/mailings/kiwi.modules.php',
 		'/core/boxes/box_members.php',
-
+		'/includes/restler/framework/Luracast/Restler/Data/Object.php',
+		
 		'/api/class/api_generic.class.php',
 		'/asterisk/cidlookup.php',
 		'/categories/class/api_category.class.php',


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
[*Long description*]
Delete deprecated file Object.php that cause REST API to crash